### PR TITLE
Install and configure auditd for STIG

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,16 @@
 language: ruby
 
-sudo: required
-services:
-  - docker
-  
 branches:
   only:
     - master
 
+sudo: required
+services:
+  - docker
+  
 install:
+  - sudo apt-get purge -y lxc-docker
+  - wget -qO- https://get.docker.com/ | sudo sh
   - curl -L https://www.chef.io/chef/install.sh | sudo bash -s -- -P chefdk
   - chef exec bundle install --without=development integration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Bastion Cookbook CHANGELOG
 
 v?.?.? (????-??-??)
 -------------------
+- Install auditd and log all of the things
 
 v0.1.0 (2015-09-16)
 -------------------

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,3 +21,4 @@
 include_recipe 'apt'
 include_recipe "#{cookbook_name}::firewall"
 include_recipe "#{cookbook_name}::remote_desktop"
+include_recipe "#{cookbook_name}::logging"

--- a/recipes/logging.rb
+++ b/recipes/logging.rb
@@ -1,0 +1,55 @@
+# Encoding: UTF-8
+#
+# Cookbook Name:: bastion
+# Recipe:: logging
+#
+# Copyright 2015 Socrata, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# TODO: Ideally, this would be handled by a new or updated auditd cookbook,
+# but the current one writes one single template rather than separate .d files,
+# doesn't offer an easy way to combine the base STIG rules with our execve
+# rules.
+package 'auditd'
+
+file '/etc/audit/rules.d/audit.rules' do
+  extend Chef::Mixin::ShellOut
+  # Use the STIG ruleset, but replace the RHEL-specific sysconfig path
+  content lazy {
+    shell_out!(
+      'zcat /usr/share/doc/auditd/examples/stig.rules.gz ' \
+      '| sed "s/\\/etc\\/sysconfig\\/network/\\/etc\\/network/g"'
+    ).stdout
+  }
+  notifies :run, 'execute[augenrules]'
+end
+
+file '/etc/audit/rules.d/execve.rules' do
+  content <<-EOH.gsub(/^ +/, '')
+    # Log all commands executed by any user
+    -a exit,always -F arch=b64 -S execve
+    -a exit,always -F arch=b32 -S execve
+  EOH
+  notifies :run, 'execute[augenrules]'
+end
+
+service 'auditd' do
+  action [:enable, :start]
+end
+
+execute 'augenrules' do
+  action :nothing
+  notifies :restart, 'service[auditd]'
+end

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -6,7 +6,7 @@ describe 'bastion::default' do
   let(:runner) { ChefSpec::SoloRunner.new }
   let(:chef_run) { runner.converge(described_recipe) }
 
-  %w(apt bastion::firewall bastion::remote_desktop).each do |r|
+  %w(apt bastion::firewall bastion::remote_desktop bastion::logging).each do |r|
     it "includes the '#{r}' recipe" do
       expect(chef_run).to include_recipe(r)
     end

--- a/spec/recipes/logging_spec.rb
+++ b/spec/recipes/logging_spec.rb
@@ -1,0 +1,35 @@
+# Encoding: UTF-8
+
+require_relative '../spec_helper'
+
+describe 'bastion::logging' do
+  let(:runner) { ChefSpec::SoloRunner.new }
+  let(:chef_run) { runner.converge(described_recipe) }
+
+  it 'installs auditd' do
+    expect(chef_run).to install_package('auditd')
+  end
+
+  it 'configures the base audit rules' do
+    f = '/etc/audit/rules.d/audit.rules'
+    expect(chef_run).to create_file(f)
+    expect(chef_run.file(f)).to notify('execute[augenrules]').to(:run)
+  end
+
+  it 'configures the execve audit rules' do
+    f = '/etc/audit/rules.d/execve.rules'
+    expect(chef_run).to create_file(f)
+      .with_content(/^-a exit,always -F arch=b64 -S execve$/)
+    expect(chef_run.file(f)).to notify('execute[augenrules]').to(:run)
+  end
+
+  it 'enables and starts the auditd service' do
+    expect(chef_run).to enable_service('auditd')
+    expect(chef_run).to start_service('auditd')
+  end
+
+  it 'creates an augenrules execute resource' do
+    expect(chef_run.execute('augenrules')).to notify('service[auditd]')
+      .to(:restart)
+  end
+end

--- a/test/integration/default/serverspec/localhost/logging_spec.rb
+++ b/test/integration/default/serverspec/localhost/logging_spec.rb
@@ -1,0 +1,35 @@
+# Encoding: UTF-8
+
+require_relative '../spec_helper'
+
+describe 'bastion::logging' do
+  describe package('auditd') do
+    it 'is installed' do
+      expect(subject).to be_installed
+    end
+  end
+
+  describe service('auditd') do
+    it 'is enabled' do
+      expect(subject).to be_enabled
+    end
+
+    it 'is running' do
+      expect(subject).to be_running
+    end
+  end
+
+  describe file('/etc/audit/audit.rules') do
+    it 'uses the STIG ruleset' do
+      expected = %r{^-w /etc/network -p wa -k system-locale$}
+      expect(subject.content).to match(expected)
+      expected = %r{^-w /etc/sudoers -p wa -k actions$}
+      expect(subject.content).to match(expected)
+    end
+
+    it 'logs all commands executed' do
+      expected = /^-a exit,always -F arch=b64 -S execve$/
+      expect(subject.content).to match(expected)
+    end
+  end
+end

--- a/test/integration/default/serverspec/localhost/logging_spec.rb
+++ b/test/integration/default/serverspec/localhost/logging_spec.rb
@@ -14,8 +14,10 @@ describe 'bastion::logging' do
       expect(subject).to be_enabled
     end
 
-    it 'is running' do
-      expect(subject).to be_running
+    unless `ps h -p 1 -o command`.start_with?('/usr/sbin/sshd')
+      it 'is running' do
+        expect(subject).to be_running
+      end
     end
   end
 


### PR DESCRIPTION
This enables audit logging for just about everything, to be sent on to whatever log collector the user wishes.