### PR TITLE
Install Snoopy and Java

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -16,4 +16,4 @@ platforms:
 suites:
   - name: default
     run_list:
-      - recipe[bastion]
+      - recipe[bastion_test]

--- a/Berksfile
+++ b/Berksfile
@@ -3,3 +3,5 @@
 source 'https://supermarket.chef.io'
 
 metadata
+
+cookbook 'bastion_test', path: 'test/fixtures/cookbooks/bastion_test'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Bastion Cookbook CHANGELOG
 v?.?.? (????-??-??)
 -------------------
 - Replace Auditd with Snoopy for logging execve calls
+- Install Oracle Java with the other dev tools
 
 v0.3.0 (2015-10-08)
 -------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Bastion Cookbook CHANGELOG
 
 v?.?.? (????-??-??)
 -------------------
+- Replace Auditd with Snoopy for logging execve calls
 
 v0.3.0 (2015-10-08)
 -------------------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,6 +18,10 @@
 # limitations under the License.
 #
 
+default['java']['jdk_version'] = 8
+default['java']['install_flavor'] = 'oracle'
+default['java']['oracle']['accept_oracle_download_terms'] = true
+
 default['snoopy']['config']['filter_chain'] = 'only_tty:'
 
 default['bastion']['firewall']['enabled'] = true

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,6 +18,8 @@
 # limitations under the License.
 #
 
+default['snoopy']['config']['filter_chain'] = 'only_tty:'
+
 default['bastion']['firewall']['enabled'] = true
 default['bastion']['firewall']['trusted_networks'] = %w(
   10.0.0.0/8

--- a/metadata.rb
+++ b/metadata.rb
@@ -15,4 +15,5 @@ depends          'apt', '~> 2.0'
 depends          'firewall', '~> 1.1.0' # TODO: firewall 1.2+ requires Chef 12+
 depends          'x2go-server', '~> 0.1'
 depends          'snoopy', '~> 1.0'
+depends          'java',   '~> 1.35'
 # rubocop:enable SingleSpaceBeforeFirstArg

--- a/metadata.rb
+++ b/metadata.rb
@@ -14,4 +14,5 @@ supports         'ubuntu'
 depends          'apt', '~> 2.0'
 depends          'firewall', '~> 1.1.0' # TODO: firewall 1.2+ requires Chef 12+
 depends          'x2go-server', '~> 0.1'
+depends          'snoopy', '~> 1.0'
 # rubocop:enable SingleSpaceBeforeFirstArg

--- a/recipes/dev_tools.rb
+++ b/recipes/dev_tools.rb
@@ -18,6 +18,8 @@
 # limitations under the License.
 #
 
+include_recipe 'java'
+
 package 'git'
 package 'ruby-dev'
 

--- a/recipes/logging.rb
+++ b/recipes/logging.rb
@@ -18,10 +18,10 @@
 # limitations under the License.
 #
 
+include_recipe 'snoopy'
+
 # TODO: Ideally, this would be handled by a new or updated auditd cookbook,
-# but the current one writes one single template rather than separate .d files,
-# doesn't offer an easy way to combine the base STIG rules with our execve
-# rules.
+# but the current one writes one single template rather than separate .d files
 package 'auditd'
 
 file '/etc/audit/rules.d/audit.rules' do
@@ -33,15 +33,6 @@ file '/etc/audit/rules.d/audit.rules' do
       '| sed "s/\\/etc\\/sysconfig\\/network/\\/etc\\/network/g"'
     ).stdout
   }
-  notifies :run, 'execute[augenrules]'
-end
-
-file '/etc/audit/rules.d/execve.rules' do
-  content <<-EOH.gsub(/^ +/, '')
-    # Log all commands executed by any user
-    -a exit,always -F arch=b64 -S execve
-    -a exit,always -F arch=b32 -S execve
-  EOH
   notifies :run, 'execute[augenrules]'
 end
 

--- a/spec/recipes/dev_tools_spec.rb
+++ b/spec/recipes/dev_tools_spec.rb
@@ -6,6 +6,11 @@ describe 'bastion::dev_tools' do
   let(:runner) { ChefSpec::SoloRunner.new }
   let(:chef_run) { runner.converge(described_recipe) }
 
+  it 'installs Oracle-flavored Java' do
+    expect(chef_run).to include_recipe('java')
+    expect(chef_run.node['java']['install_flavor']).to eq('oracle')
+  end
+
   it 'installs Git' do
     expect(chef_run).to install_package('git')
   end

--- a/spec/recipes/logging_spec.rb
+++ b/spec/recipes/logging_spec.rb
@@ -6,6 +6,10 @@ describe 'bastion::logging' do
   let(:runner) { ChefSpec::SoloRunner.new }
   let(:chef_run) { runner.converge(described_recipe) }
 
+  it 'installs Snoopy' do
+    expect(chef_run).to include_recipe('snoopy')
+  end
+
   it 'installs auditd' do
     expect(chef_run).to install_package('auditd')
   end
@@ -16,19 +20,13 @@ describe 'bastion::logging' do
     expect(chef_run.file(f)).to notify('execute[augenrules]').to(:run)
   end
 
-  it 'configures the execve audit rules' do
-    f = '/etc/audit/rules.d/execve.rules'
-    expect(chef_run).to create_file(f)
-      .with_content(/^-a exit,always -F arch=b64 -S execve$/)
-    expect(chef_run.file(f)).to notify('execute[augenrules]').to(:run)
-  end
-
   it 'enables and starts the auditd service' do
     expect(chef_run).to enable_service('auditd')
     expect(chef_run).to start_service('auditd')
   end
 
   it 'creates an augenrules execute resource' do
+    expect(chef_run.execute('augenrules')).to do_nothing
     expect(chef_run.execute('augenrules')).to notify('service[auditd]')
       .to(:restart)
   end

--- a/test/fixtures/cookbooks/bastion_test/metadata.rb
+++ b/test/fixtures/cookbooks/bastion_test/metadata.rb
@@ -1,0 +1,15 @@
+# Encoding: UTF-8
+#
+# rubocop:disable SingleSpaceBeforeFirstArg
+name             'bastion_test'
+maintainer       'Jonathan Hartman'
+maintainer_email 'jonathan.hartman@socrata.com'
+license          'apache2'
+description      'bastion_test'
+long_description 'bastion_test'
+version          '0.0.1'
+
+depends          'bastion'
+
+supports         'ubuntu'
+# rubocop:enable SingleSpaceBeforeFirstArg

--- a/test/fixtures/cookbooks/bastion_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/bastion_test/recipes/default.rb
@@ -1,0 +1,8 @@
+# Encoding: UTF-8
+
+service 'rsyslog' do
+  start_command 'service rsyslog start'
+  action :start
+end
+
+include_recipe 'bastion'

--- a/test/integration/default/serverspec/localhost/dev_tools_spec.rb
+++ b/test/integration/default/serverspec/localhost/dev_tools_spec.rb
@@ -3,6 +3,12 @@
 require_relative '../spec_helper'
 
 describe 'bastion::dev_tools' do
+  describe file('/usr/lib/jvm/java-8-oracle-amd64/bin/java') do
+    it 'exists' do
+      expect(subject).to be_file
+    end
+  end
+
   describe package('git') do
     it 'is installed' do
       expect(subject).to be_installed

--- a/test/integration/default/serverspec/localhost/logging_spec.rb
+++ b/test/integration/default/serverspec/localhost/logging_spec.rb
@@ -3,6 +3,31 @@
 require_relative '../spec_helper'
 
 describe 'bastion::logging' do
+  describe package('snoopy') do
+    it 'is installed' do
+      expect(subject).to be_installed
+    end
+  end
+
+  describe file('/etc/ld.so.preload') do
+    it 'loads the snoopy lib' do
+      expect(subject.content).to match(%r{^/lib/libsnoopy\.so$})
+    end
+  end
+
+  describe file('/etc/snoopy.ini') do
+    it 'is configured to only log commands with a TTY' do
+      expect(subject.content).to match(/^filter_chain = only_tty:$/)
+    end
+  end
+
+  describe file('/var/log/auth.log') do
+    it 'is logging system commands' do
+      `ls`
+      expect(subject.content).to match(%r{snoopy.*filename:/bin/ls})
+    end
+  end
+
   describe package('auditd') do
     it 'is installed' do
       expect(subject).to be_installed
@@ -26,11 +51,6 @@ describe 'bastion::logging' do
       expected = %r{^-w /etc/network -p wa -k system-locale$}
       expect(subject.content).to match(expected)
       expected = %r{^-w /etc/sudoers -p wa -k actions$}
-      expect(subject.content).to match(expected)
-    end
-
-    it 'logs all commands executed' do
-      expected = /^-a exit,always -F arch=b64 -S execve$/
       expect(subject.content).to match(expected)
     end
   end


### PR DESCRIPTION
* Switch logging of `execve` system calls to Snoopy for the less verbose and more easily parseable logs
* Keep Auditd running with the STIG ruleset, for now, though I could be persuaded otherwise
* Install Oracle Java